### PR TITLE
move content metadata to the encrypted payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
+/coverage
+*.profdata
+*.profraw
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/bin/main.rs"
 required-features = ["cli"]
 
 [features]
+default = ["miniscript_latest"]
 miniscript_latest = ["miniscript_12_3_5"]
 miniscript_12_3_5 = ["mscript_12_3_5"]
 miniscript_12_0 = ["mscript_12_0"]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ let descriptor = EncryptedBackup::new()
 |---------------------|---------|-------------------------------------------------------|
 | `miniscript_12_0`   | –       | Compile against `miniscript` v0.12.0                  |
 | `miniscript_12_3_5` | –       | Compile against `miniscript` v0.12.3.5                |
-| `miniscript_latest` | –       | Alias for `miniscript_12_3_5`                         |
+| `miniscript_latest` | ✓       | Alias for `miniscript_12_3_5`                         |
 | `devices`           | ✓       | Enable automatic enumeration of signing devices.      |
 | `tokio`             | ✓       | Pull in `tokio` runtime used by the `devices`feature. |
 

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -40,7 +40,7 @@ fn dpk_to_deriv_path(key: &DescriptorPublicKey) -> Option<DerivationPath> {
 // > lift_x(0x50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0) which is constructed
 // > by taking the hash of the standard uncompressed encoding of the secp256k1 base point G as X
 // > coordinate.
-fn bip341_nums() -> bitcoin::secp256k1::PublicKey {
+pub fn bip341_nums() -> bitcoin::secp256k1::PublicKey {
     bitcoin::secp256k1::PublicKey::from_str(
         "0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
     )

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -103,7 +103,7 @@ pub mod tests {
         Descriptor::<DescriptorPublicKey>::from_str(descr_str).unwrap()
     }
 
-    fn dpk_1() -> DescriptorPublicKey {
+    pub fn dpk_1() -> DescriptorPublicKey {
         let dpk_str = "[58b7f8dc/48'/1'/0'/2']tpubDEPBvXvhta3pjVaKokqC3eeMQnszj9ehFaA2zD5nSdkaccwGAizu8jVB2NeSpvmP2P52MBoZvNCixqXRJnTyXx51FQzARR63tjxQSyP3Btw/<0;1>/*";
         DescriptorPublicKey::from_str(dpk_str).unwrap()
     }


### PR DESCRIPTION
This PR move content metada in the encrypted payload and allow to define the content in a different BIP

partially adresses this [comment(https://github.com/bitcoin/bips/pull/1951#discussion_r2321215113)

